### PR TITLE
Move component-specific libraries to optional peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "url": "git+https://github.com/AppsDevTeam/js-components.git"
   },
   "dependencies": {
+    "nette.ajax.js": "^2.3.0"
+  },
+  "peerDependencies": {
+    "jquery": "^3.4.1",
     "select2": "^4.0.13",
     "select2-bootstrap-5-theme": "^1.1.1",
     "autonumeric": "^4.6.0",
@@ -23,14 +27,28 @@
     "scrollparent": "^2.0.1",
     "tinymce": "^5.7.0",
     "tinymce-i18n": "^20.12.25",
-    "nette.ajax.js": "^2.3.0",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
     "firebase": "^12.10.0",
     "@firebase/messaging": "^0.12.24"
   },
-  "peerDependencies": {
-    "jquery": "^3.4.1"
+  "peerDependenciesMeta": {
+    "select2": { "optional": true },
+    "select2-bootstrap-5-theme": { "optional": true },
+    "autonumeric": { "optional": true },
+    "@here/flexpolyline": { "optional": true },
+    "flatpickr": { "optional": true },
+    "script-loader": { "optional": true },
+    "timepicker": { "optional": true },
+    "glightbox": { "optional": true },
+    "@googlemaps/js-api-loader": { "optional": true },
+    "scrollparent": { "optional": true },
+    "tinymce": { "optional": true },
+    "tinymce-i18n": { "optional": true },
+    "leaflet": { "optional": true },
+    "leaflet.markercluster": { "optional": true },
+    "firebase": { "optional": true },
+    "@firebase/messaging": { "optional": true }
   },
   "author": "Apps Dev Team",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "tinymce-i18n": "^20.12.25",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
-    "firebase": "^12.10.0",
-    "@firebase/messaging": "^0.12.24"
+    "firebase": "^12.10.0"
   },
   "peerDependenciesMeta": {
     "select2": { "optional": true },
@@ -47,8 +46,7 @@
     "tinymce-i18n": { "optional": true },
     "leaflet": { "optional": true },
     "leaflet.markercluster": { "optional": true },
-    "firebase": { "optional": true },
-    "@firebase/messaging": { "optional": true }
+    "firebase": { "optional": true }
   },
   "author": "Apps Dev Team",
   "license": "MIT",


### PR DESCRIPTION
Users now install only the libraries required by the components they actually use, instead of pulling all heavy dependencies (firebase, tinymce, leaflet, google maps, ...) automatically.